### PR TITLE
Refactor to separate data model from presentation/view code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 composer.lock
 composer.phar
+atlassian-ide-plugin.xml
+.idea/


### PR DESCRIPTION
Hey,

I did some refactoring work to separate the mixed domain logic and presentation information. I didnt go too far, in that now, there are some methods in the OpCacheDataModel which contain some HTML. These could be further refactored, but, I thought it best to get a pull request in at this stage to avoid getting too far behind master for such a significant rework of the code structure.

ck
