### PR TITLE
"Uncaught SyntaxError: Unexpected token var" fixed.

### DIFF
--- a/opcache.php
+++ b/opcache.php
@@ -542,7 +542,7 @@ $dataModel = new OpCacheDataModel();
     <div id="partition"></div>
 
     <script>
-        var dataset = <?php echo $dataModel->getGraphDataSetJson(); ?>
+        var dataset = <?php echo $dataModel->getGraphDataSetJson(); ?>;
 
         var width = 400,
             height = 400,


### PR DESCRIPTION
Caused by no semicolon at the end of the json object