### PR TITLE
Do not crash on status and script tabs if opcache is disabled

### DIFF
--- a/opcache.php
+++ b/opcache.php
@@ -27,6 +27,11 @@ class OpCacheDataModel
     public function getStatusDataRows()
     {
         $rows = array();
+
+        if (empty($this->_status)) {
+            return "<br> Opcache disabled";
+        }
+
         foreach ($this->_status as $key => $value) {
             if ($key === 'scripts') {
                 continue;

--- a/opcache.php
+++ b/opcache.php
@@ -103,6 +103,11 @@ class OpCacheDataModel
 
     public function getScriptStatusRows()
     {
+        
+        if (empty($this->_status)) {
+            return "<br> Opcache disabled";
+        }
+        
         foreach ($this->_status['scripts'] as $key => $data) {
             $dirs[dirname($key)][basename($key)] = $data;
             $this->_arrayPset($this->_d3Scripts, $key, array(


### PR DESCRIPTION
Do not crash on status and script tabs if opcache is disabled,
return opcache disabled message instead